### PR TITLE
Add version tag to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 FROM python:3.6-alpine
-MAINTAINER <https://github.com/o2r-project>
 
 RUN apk add --no-cache wget git \
     && git clone --depth 1 -b master https://github.com/o2r-project/o2r-shipper /shipper \
@@ -30,14 +29,15 @@ ARG VCS_REF
 ARG BUILD_DATE
 
 # Metadata http://label-schema.org/rc1/
-LABEL org.label-schema.vendor="o2r project" \
-      org.label-schema.url="http://o2r.info" \
-      org.label-schema.name="o2r shipper" \
-      org.label-schema.description="ERC shipping to repositories" \    
-      org.label-schema.vcs-url=$VCS_URL \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.docker.schema-version="rc1"
+LABEL maintainer="o2r project <https://github.com/o2r-project>" \
+    org.label-schema.vendor="o2r project" \
+    org.label-schema.url="http://o2r.info" \
+    org.label-schema.name="o2r shipper" \
+    org.label-schema.description="ERC shipping to repositories" \    
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.docker.schema-version="rc1"
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["python", "shipper.py"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 FROM python:3.6-alpine
-MAINTAINER <https://github.com/o2r-project>
+LABEL maintainer="o2r project <https://github.com/o2r-project>"
 
 RUN apk add --no-cache wget \
     && wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 \

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+VCS_REF=`git rev-parse --short HEAD`
+echo Add version tag using git short rev $VCS_REF
+
+docker tag $IMAGE_NAME $DOCKER_REPO:$VCS_REF
+docker push $DOCKER_REPO:$VCS_REF


### PR DESCRIPTION
With this merged, the Docker images will get the git commit as a tag, so that users can pull and run specific versions, e.g.

```bash
docker run o2rproject/o2r-shipper:7411b1
```