### PR TITLE
Fix repo verification for Zenodo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,13 @@ before_install:
 install:
   - pip install -U pytest requests
 before_script:
+  - mkdir /tmp/o2r
   - docker run --name mongodb -d -p 27017:27017 mongo:3.4
-  - docker run --name testloader -d -p 8088:8088 --link mongodb:mongodb -v $HOME:/tmp/o2r -e LOADER_MONGODB=mongodb://mongodb:27017 -e DEBUG=* o2rproject/o2r-loader:latest
-  - docker run --name testmuncher -d -p 8080:8080 --link mongodb:mongodb -v $HOME:/tmp/o2r -v /var/run/docker.sock:/var/run/docker.sock -e MUNCHER_MONGODB=mongodb://mongodb:27017 -e DEBUG=muncher,muncher:* o2rproject/o2r-muncher:latest
+  - docker run --name testloader  -d -p 8088:8088 --link mongodb:mongodb -v /tmp/o2r:/tmp/o2r -v /var/run/docker.sock:/var/run/docker.sock -e LOADER_MONGODB=mongodb://mongodb:27017  -e DEBUG=* o2rproject/o2r-loader:latest
+  - docker run --name testmuncher -d -p 8080:8080 --link mongodb:mongodb -v /tmp/o2r:/tmp/o2r -v /var/run/docker.sock:/var/run/docker.sock -e MUNCHER_MONGODB=mongodb://mongodb:27017 -e DEBUG=muncher,muncher:* o2rproject/o2r-muncher:latest
   - docker build --tag shipper .
   - |-
-    docker run --name testshipper -t -d -p 8087:8087 --link mongodb:mongodb -v $HOME:/tmp/o2r -e SHIPPER_REPO_TOKENS='{"download": "none"}' -e SHIPPER_BOTTLE_HOST=0.0.0.0 -e SHIPPER_MONGODB=mongodb://mongodb:27017/ shipper
+    docker run --name testshipper -t -d -p 8087:8087 --link mongodb:mongodb -v /tmp/o2r:/tmp/o2r -e SHIPPER_REPO_TOKENS='{"download": "none"}' -e SHIPPER_BOTTLE_HOST=0.0.0.0 -e SHIPPER_MONGODB=mongodb://mongodb:27017/ shipper
   - sleep 10
 script:
   - pytest

--- a/repos/repozenodo.py
+++ b/repos/repozenodo.py
@@ -23,7 +23,7 @@ class RepoClassZenodo(Repo):
             global ID
             # get file id from bucket url:
             headers = {"Content-Type": "application/json"}
-            r = requests.get(''.join((HOST, '/deposit/depositions/', '?access_token=', token)), headers=headers, verify=True, timeout=3)
+            r = requests.get(''.join((HOST, '/deposit/depositions', '?access_token=', token)), headers=headers, verify=True, timeout=3)
             status_note(['<', ID, '> token verification: ', xstr(r.status_code), ' ', xstr(r.reason)])
             if r.status_code == 200:
                 return True

--- a/repos/repozenodosandbox.py
+++ b/repos/repozenodosandbox.py
@@ -23,7 +23,7 @@ class RepoClassZenodo(Repo):
             global ID
             # get file id from bucket url:
             headers = {"Content-Type": "application/json"}
-            r = requests.get(''.join((HOST, '/deposit/depositions/', '?access_token=', token)), headers=headers, verify=True, timeout=3)
+            r = requests.get(''.join((HOST, '/deposit/depositions', '?access_token=', token)), headers=headers, verify=True, timeout=3)
             status_note(['<', ID, '> token verification: ', xstr(r.status_code), ' ', xstr(r.reason)])
             if r.status_code == 200:
                 return True


### PR DESCRIPTION
Maybe Zenodo has changed their configuration, but both @jansule and me could not start the shipper this morning, with the same error:

```
[shipper] <download> (surrogate) OK
[shipper] <zenodo_sandbox> token verification: 404 NOT FOUND
[shipper] 1 repositories configured
[shipper] connecting to mongodb://localhost:27017/
```

Turns out the URL used to verify the token does not work when there is a trailing `/` before the query parameter:

- does *not* work: `https://sandbox.zenodo.org/api/deposit/depositions/?access_token=...`
- works: `https://sandbox.zenodo.org/api/deposit/depositions?access_token=..`

This PR also contains an update to the Travis configuration to work with new loader and muncher versions.